### PR TITLE
Update RiichiBook1-ch3-basics.tex

### DIFF
--- a/RiichiBook1-ch3-basics.tex
+++ b/RiichiBook1-ch3-basics.tex
@@ -757,7 +757,7 @@ Shape & 3-way & 2-way & 1-way & Pair & Acceptance\\
 {\LARGE\wan{2}\wan{3}\wan{4}\wan{6}}
 	& {\LARGE\wan{5}}
 	& {\LARGE\wan{7}}
-	& {\LARGE \wan{1} \wan{8}}
+	& {\LARGE \wan{1} \wan{4} \wan{8}}
 	& {\LARGE \wan{6}}
 	& 6 kinds--22 tiles\\ [\sep]
 {\LARGE\wan{3}\wan{4}\wan{5}\wan{7}}


### PR DESCRIPTION
2346 skipping shape in table 3.4 should accept 6 types, but only 5 are listed. Added 4 man to the "1-way" column of the table.