### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: bionic
+language: minimal
+branches:
+  only:
+  - master
+before_install:
+- sudo apt-get update
+- sudo apt-get install -y texlive-latex-base texlive-latex-extra texlive-luatex texlive-lang-polish
+  texlive-lang-japanese texlive-fonts-recommended tex-gyre tipa
+jobs:
+  include:
+  - stage: build
+    script:
+    - TEXMFHOME=./texmf platex RiichiBook1.tex
+    - TEXMFHOME=./texmf platex RiichiBook1.tex
+    - TEXMFHOME=./texmf dvipdfmx RiichiBook1.dvi
+before_deploy:
+- git tag -f latest
+deploy:
+  provider: releases
+  api_key:
+    secure: WbLA7p9Zpb373ACBLESDJpdgq7BNarjt/TdJ9j0Dx88wwNmUFkLZ0LUUahHimuPLy4CP2Cnw1VeavSbP6JZLxWBbRn3iPqDVVDsXAAPMOy+HpBoVkLrYP1ZH2Hw4PfH0ga5hN/OGIc3Riq5VhARItJ+X8nD0AMqxRH+nAZWjXEb2frKc365xBYRdniNgQJSuUjThdBoNIRFvgJEIMWfYmNc2UFbQ831jhqbxpdhHVZWP6HARyZi8D6nOUgJsfFXo7USXcp1CvdYDser9xFSdPa0rnJVWxKQKSbi+SGvAkglOgjhaMkrAg1usIJHss4gckLOT587AokQcoKHw04ovEdHBL4gNM46SlHoSfUu0nlR+G5uCdJ+CuITUtqQaJoU+5rVia2s3ZrSCn7tvMrWCpM+7LJBUnmVP0ddjdTRL+ov4uvtIL3+qWWGtuIjLNAsOjGuBRnK5Vk/CSdp3NmIrNc/X4ELAhrRYQaivq1zxdTv6SFuw37uliesRFXLjsnCKhck+fo4Nk9T819yB6Pcm/PbI0RcEUJqw1lzFfyr8Vqtio/l8QJbXYwraObYFlTGEOYTJtciDNP/fR87tlQEN4Ijb1wtcQA8W5coxUH+uINbsa9dSLoq7/yQsRuhqbjLKcSL1SVCZ2FhT+3f+7vxy1Cz8TZOH0BdqfBI3upcxkW8=
+  file: RiichiBook1.pdf
+  on:
+    repo: riichi/RiichiBooks
+  skip_cleanup: true
+  overwrite: true
+


### PR DESCRIPTION
This add Travis configuration to the repository, allowing Travis to automatically build the book on each change and publish the most recent version to GitHub releases.

The passing build at our fork is available at https://travis-ci.com/riichi/RiichiBooks/jobs/243366025
The example built book is at https://github.com/riichi/RiichiBooks/releases

Kudos to @Iipin for fixing DPI issues when building the book.

## Warning: DO NOT MERGE THIS PR AS-IS.

Line 22 in the Travis configuration needs to be modified with a custom GitHub token in order for the book to be uploaded; see Travis tutorials for how it should be done.

I could configure Travis myself, but that would require me getting persistent access to the repository, since the created token will be associated with my GitHub account. I could possibly guide you through the process of performing this process yourself.