### PR TITLE
Typo correction

### DIFF
--- a/RiichiBook1-ch3-basics.tex
+++ b/RiichiBook1-ch3-basics.tex
@@ -710,7 +710,7 @@ Try to keep a bulging float shape until a hand becomes 1-away.
 
 \subsubsection{Skipping shape}
 \index{skipping shape}
-When we have a floating tile two tiles away from a run, we have a {\bf skipping shape}. For example, in a shape {\LARGE\wan{3}\wan{5}\wan{6}\wan{7}}, {\LARGE\wan{3}} is floating next to a run {\LARGE\wan{5}\wan{6}\wan{7}}. {\LARGE\wan{3}} in a skipping shape is more valuable than isolated {\LARGE\wan{3}}, because it increases the kinds of tiles the hand can accept to produce a protorun or a 3-way side-wait shape. Table \ref{tbl:skipping} summarizes all the skipping shapes and the tiles each shape can accept. 
+When we have a floating tile two tiles away from a run, we have a {\bf skipping shape}. For example, in a shape {\LARGE\wan{3}\wan{5}\wan{6}\wan{7}}, {\LARGE\wan{3}} is floating two tiles from a run {\LARGE\wan{5}\wan{6}\wan{7}}. {\LARGE\wan{3}} in a skipping shape is more valuable than isolated {\LARGE\wan{3}}, because it increases the kinds of tiles the hand can accept to produce a protorun or a 3-way side-wait shape. Table \ref{tbl:skipping} summarizes all the skipping shapes and the tiles each shape can accept. 
 
 {\begin{table}[h!]\centering\small\captionsetup{font=footnotesize}
 \caption{Types of skipping shapes} \label{tbl:skipping}

--- a/RiichiBook1-ch3-basics.tex
+++ b/RiichiBook1-ch3-basics.tex
@@ -710,7 +710,7 @@ Try to keep a bulging float shape until a hand becomes 1-away.
 
 \subsubsection{Skipping shape}
 \index{skipping shape}
-When we have a floating tile two tiles away from a run, we have a {\bf skipping shape}. For example, in a shape {\LARGE\wan{3}\wan{5}\wan{6}\wan{7}}, {\LARGE\wan{3}} is floating next next to a run {\LARGE\wan{5}\wan{6}\wan{7}}. {\LARGE\wan{3}} in a skipping shape is more valuable than isolated {\LARGE\wan{3}}, because it increases the kinds of tiles the hand can accept to produce a protorun or a 3-way side-wait shape. Table \ref{tbl:skipping} summarizes all the skipping shapes and the tiles each shape can accept. 
+When we have a floating tile two tiles away from a run, we have a {\bf skipping shape}. For example, in a shape {\LARGE\wan{3}\wan{5}\wan{6}\wan{7}}, {\LARGE\wan{3}} is floating next to a run {\LARGE\wan{5}\wan{6}\wan{7}}. {\LARGE\wan{3}} in a skipping shape is more valuable than isolated {\LARGE\wan{3}}, because it increases the kinds of tiles the hand can accept to produce a protorun or a 3-way side-wait shape. Table \ref{tbl:skipping} summarizes all the skipping shapes and the tiles each shape can accept. 
 
 {\begin{table}[h!]\centering\small\captionsetup{font=footnotesize}
 \caption{Types of skipping shapes} \label{tbl:skipping}


### PR DESCRIPTION
There appears to be an extra word in the text.

From:
> {\LARGE\wan{3}} is floating next next to a run

To:
> {\LARGE\wan{3}} is floating next to a run